### PR TITLE
Create standalone blog and admin workflow

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Dashboard · Aiden Yue</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/svg+xml" href="assets/avatar.svg" />
+  </head>
+  <body data-page="admin">
+    <div class="glow"></div>
+    <header class="site-header">
+      <div class="brand">
+        <span class="logo">AY</span>
+        <span class="name">Aiden Yue</span>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#experience">Experience</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#skills">Skills</a>
+        <a href="blog.html">Blog</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <button class="theme-toggle" type="button" aria-label="Activate light mode">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
+    </header>
+
+    <main class="admin-main">
+      <section class="admin-welcome">
+        <div>
+          <p class="eyebrow">Secure dashboard</p>
+          <h1>Welcome back, administrator.</h1>
+          <p class="lede">
+            Review live portfolio data and craft new blog dispatches for the
+            public site—all protected by your secure login.
+          </p>
+        </div>
+        <button class="button ghost" type="button" data-logout>Log out</button>
+      </section>
+
+      <section class="admin-overview">
+        <div class="section-heading">
+          <h2>Website overview</h2>
+          <p>
+            Key data points pulled from the public-facing experience to keep you
+            oriented while updating content.
+          </p>
+        </div>
+        <div class="admin-overview__grid" data-admin-data></div>
+      </section>
+
+      <section class="admin-blog-panel">
+        <div class="admin-blog__form">
+          <h2>Create a blog post</h2>
+          <p>
+            Draft a new dispatch to immediately publish across the site. Posts
+            appear here and on the public blog page in reverse chronological
+            order.
+          </p>
+          <form data-admin-blog-form novalidate>
+            <label>
+              <span>Title</span>
+              <input type="text" name="title" required />
+            </label>
+            <label>
+              <span>Summary</span>
+              <textarea name="summary" rows="5" required></textarea>
+            </label>
+            <label>
+              <span>Link (optional)</span>
+              <input type="url" name="link" placeholder="https://" />
+            </label>
+            <button class="button primary" type="submit">Publish post</button>
+          </form>
+        </div>
+        <div class="admin-blog__list">
+          <h2>Published posts</h2>
+          <p class="admin-blog__empty" data-admin-empty hidden>
+            No custom posts yet. Add your first dispatch using the form.
+          </p>
+          <div class="blog-grid" data-admin-posts></div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        © <span id="year"></span> Aiden Yue. Crafted with intent.
+        <a class="admin-access" href="login.html">Admin login</a>
+      </p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog · Aiden Yue</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/svg+xml" href="assets/avatar.svg" />
+  </head>
+  <body data-page="blog">
+    <div class="glow"></div>
+    <header class="site-header">
+      <div class="brand">
+        <span class="logo">AY</span>
+        <span class="name">Aiden Yue</span>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#experience">Experience</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#skills">Skills</a>
+        <a href="blog.html" aria-current="page">Blog</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <button class="theme-toggle" type="button" aria-label="Activate light mode">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
+    </header>
+
+    <main>
+      <section class="blog-hero">
+        <p class="eyebrow">Dispatches</p>
+        <h1>Stories from the lab and the venture studio.</h1>
+        <p class="lede">
+          Dig into the experiments, leadership lessons, and community insights
+          powering Asynq Ventures and my cardiology research journey.
+        </p>
+        <div class="hero-actions">
+          <a class="button primary" href="index.html#contact">Start a collaboration</a>
+          <a class="button ghost" href="index.html">Return to portfolio</a>
+        </div>
+      </section>
+
+      <section class="blog-listing">
+        <div class="section-heading">
+          <h2>Latest writing</h2>
+          <p>
+            Published pieces update automatically when new posts go live through
+            the admin dashboard.
+          </p>
+        </div>
+        <div class="blog-grid" data-blog-grid></div>
+        <p class="blog-empty" data-blog-empty hidden>
+          New essays are coming soon—check back for fresh insights.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        © <span id="year"></span> Aiden Yue. Crafted with intent.
+        <a class="admin-access" href="login.html">Admin login</a>
+      </p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/svg+xml" href="assets/avatar.svg" />
   </head>
-  <body>
+  <body data-page="home">
     <div class="glow"></div>
     <header class="site-header">
       <div class="brand">
@@ -25,12 +25,12 @@
         <span class="name">Aiden Yue</span>
       </div>
       <nav class="site-nav" aria-label="Primary">
-        <a href="#about">About</a>
-        <a href="#experience">Experience</a>
-        <a href="#projects">Projects</a>
-        <a href="#skills">Skills</a>
-        <a href="#blog">Blog</a>
-        <a href="#contact">Contact</a>
+        <a href="index.html#about">About</a>
+        <a href="index.html#experience">Experience</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#skills">Skills</a>
+        <a href="blog.html">Blog</a>
+        <a href="index.html#contact">Contact</a>
       </nav>
       <button class="theme-toggle" type="button" aria-label="Activate light mode">
         <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
@@ -278,25 +278,6 @@
         </div>
       </section>
 
-      <section class="blog" id="blog">
-        <div class="section-heading blog-heading">
-          <div>
-            <h2>Blog &amp; Dispatches</h2>
-            <p>
-              Essays on entrepreneurship, health innovation, and the lessons I’m
-              collecting while building Asynq ventures alongside rigorous
-              scientific research.
-            </p>
-          </div>
-          <button class="admin-trigger" type="button" aria-haspopup="dialog">
-            <span class="material-symbols-outlined" aria-hidden="true">lock</span>
-            Admin
-          </button>
-        </div>
-        <div class="blog-grid" data-empty="true"></div>
-        <p class="blog-empty">New essays are coming soon—check back for fresh insights.</p>
-      </section>
-
       <section class="contact" id="contact">
         <div class="contact-card">
           <h2>Let’s collaborate</h2>
@@ -324,51 +305,11 @@
     </main>
 
     <footer class="site-footer">
-      <p>© <span id="year"></span> Aiden Yue. Crafted with intent.</p>
+      <p>
+        © <span id="year"></span> Aiden Yue. Crafted with intent.
+        <a class="admin-access" href="login.html">Admin login</a>
+      </p>
     </footer>
-
-    <div class="admin-modal" role="dialog" aria-modal="true" aria-labelledby="admin-title" hidden>
-      <div class="admin-modal__content">
-        <button class="admin-close" type="button" aria-label="Close admin panel">
-          <span class="material-symbols-outlined" aria-hidden="true">close</span>
-        </button>
-        <div class="admin-forms">
-          <form class="admin-login" novalidate>
-            <h3 id="admin-title">Admin login</h3>
-            <p>Securely publish new blog entries.</p>
-            <label>
-              <span>Username</span>
-              <input type="text" name="username" autocomplete="username" required />
-            </label>
-            <label>
-              <span>Password</span>
-              <input type="password" name="password" autocomplete="current-password" required />
-            </label>
-            <button class="button primary" type="submit">Access dashboard</button>
-            <p class="form-error" role="alert" hidden>Invalid credentials. Please try again.</p>
-          </form>
-          <form class="admin-dashboard" hidden>
-            <h3>Publish a post</h3>
-            <label>
-              <span>Title</span>
-              <input type="text" name="title" required />
-            </label>
-            <label>
-              <span>Summary</span>
-              <textarea name="summary" rows="4" required></textarea>
-            </label>
-            <label>
-              <span>Link (optional)</span>
-              <input type="url" name="link" placeholder="https://" />
-            </label>
-            <div class="admin-actions">
-              <button class="button primary" type="submit">Add blog post</button>
-              <button class="button ghost admin-logout" type="button">Log out</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
 
     <script src="script.js"></script>
   </body>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Access · Aiden Yue</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/svg+xml" href="assets/avatar.svg" />
+  </head>
+  <body data-page="login">
+    <div class="glow"></div>
+    <header class="site-header">
+      <div class="brand">
+        <span class="logo">AY</span>
+        <span class="name">Aiden Yue</span>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#experience">Experience</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#skills">Skills</a>
+        <a href="blog.html">Blog</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <button class="theme-toggle" type="button" aria-label="Activate light mode">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
+    </header>
+
+    <main class="auth-main">
+      <section class="auth-card">
+        <h1>Administrator access</h1>
+        <p>
+          Sign in with your assigned credentials to manage live website data and
+          publish new blog entries.
+        </p>
+        <form data-login-form novalidate>
+          <label>
+            <span>Username</span>
+            <input type="text" name="username" autocomplete="username" required />
+          </label>
+          <label>
+            <span>Password</span>
+            <input
+              type="password"
+              name="password"
+              autocomplete="current-password"
+              required
+            />
+          </label>
+          <button class="button primary" type="submit">Enter dashboard</button>
+          <p class="form-error" data-login-error hidden>
+            Access denied. Please check your username and password.
+          </p>
+        </form>
+        <p class="auth-hint">
+          Hint: credentials are case sensitive. Reach out to Aiden if you need
+          them reset.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        © <span id="year"></span> Aiden Yue. Crafted with intent.
+        <a class="admin-access" href="login.html" aria-current="page">Admin login</a>
+      </p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,10 @@ main,
   transition: color 0.3s ease;
 }
 
+.site-nav a[aria-current='page'] {
+  color: var(--text);
+}
+
 .site-nav a:hover,
 .site-nav a:focus {
   color: var(--text);
@@ -261,38 +265,6 @@ section h2 {
   max-width: 640px;
 }
 
-.blog-heading {
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 32px;
-}
-
-.blog-heading > div {
-  flex: 1;
-}
-
-.admin-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--muted);
-  font-weight: 500;
-  cursor: pointer;
-  transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease;
-}
-
-.admin-trigger:hover,
-.admin-trigger:focus-visible {
-  transform: translateY(-2px);
-  background: rgba(124, 92, 255, 0.12);
-  color: var(--text);
-}
-
 .blog {
   position: relative;
 }
@@ -356,10 +328,90 @@ section h2 {
   text-align: center;
 }
 
+.blog-hero {
+  max-width: 820px;
+}
+
+.blog-hero .hero-actions {
+  margin-top: 32px;
+}
+
+.blog-listing {
+  display: grid;
+  gap: 32px;
+}
+
+.blog-card__meta {
+  margin: 0;
+  color: rgba(244, 246, 255, 0.6);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .timeline {
   margin-top: 48px;
   display: grid;
   gap: 28px;
+}
+
+.auth-main {
+  min-height: calc(100vh - 320px);
+  display: grid;
+  place-items: center;
+  padding: 80px 32px 120px;
+}
+
+.auth-card {
+  width: min(440px, 100%);
+  padding: 48px;
+  border-radius: calc(var(--radius) * 1.1);
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 24px;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.auth-card form {
+  display: grid;
+  gap: 18px;
+}
+
+.auth-card label {
+  display: grid;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.auth-card input {
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font: inherit;
+}
+
+.auth-card input:focus {
+  outline: 2px solid rgba(124, 92, 255, 0.4);
+  outline-offset: 0;
+}
+
+.auth-hint {
+  font-size: 0.9rem;
+  color: rgba(244, 246, 255, 0.6);
 }
 
 .timeline-item {
@@ -544,6 +596,121 @@ section h2 {
   background: rgba(124, 92, 255, 0.12);
 }
 
+.admin-main {
+  max-width: 1100px;
+  margin: 80px auto 120px;
+  padding: 0 32px;
+  display: grid;
+  gap: 80px;
+}
+
+.admin-welcome {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.admin-welcome > div {
+  flex: 1;
+  min-width: 260px;
+}
+
+.admin-overview__grid {
+  margin-top: 40px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.admin-data-card {
+  padding: 28px;
+  border-radius: var(--radius);
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+}
+
+.admin-data-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(244, 246, 255, 0.7);
+}
+
+.admin-data-card__value {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.admin-data-card__helper {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.admin-blog-panel {
+  display: grid;
+  gap: 40px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  align-items: start;
+}
+
+.admin-blog__form,
+.admin-blog__list {
+  padding: 32px;
+  border-radius: var(--radius);
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 24px;
+}
+
+.admin-blog__form form {
+  display: grid;
+  gap: 18px;
+}
+
+.admin-blog__form label {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.admin-blog__form input,
+.admin-blog__form textarea {
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font: inherit;
+  resize: vertical;
+}
+
+.admin-blog__form input:focus,
+.admin-blog__form textarea:focus {
+  outline: 2px solid rgba(124, 92, 255, 0.4);
+  outline-offset: 0;
+}
+
+.admin-blog__empty {
+  margin: 0;
+  color: rgba(244, 246, 255, 0.65);
+}
+
+.admin-blog__list .blog-grid {
+  margin-top: 0;
+}
+
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
 }
@@ -556,103 +723,25 @@ section h2 {
   text-align: center;
 }
 
-.admin-modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(4, 1, 10, 0.75);
-  backdrop-filter: blur(8px);
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  z-index: 10;
-}
-
-.admin-modal[hidden] {
-  display: none;
-}
-
-.admin-modal__content {
-  width: min(480px, 100%);
-  padding: 40px;
-  border-radius: calc(var(--radius) * 1.1);
-  background: var(--bg-alt);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: var(--shadow);
-  position: relative;
-  display: grid;
-  gap: 24px;
-}
-
-.admin-close {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-}
-
-.admin-forms form {
-  display: grid;
-  gap: 16px;
-}
-
-.admin-forms label {
-  display: grid;
-  gap: 8px;
+.admin-access {
+  margin-left: 12px;
+  font-size: 0.85rem;
   color: var(--muted);
-  font-size: 0.95rem;
+  text-decoration: none;
+  border-bottom: 1px dotted rgba(255, 255, 255, 0.25);
+  transition: color 0.3s ease, border-color 0.3s ease;
 }
 
-.admin-forms input,
-.admin-forms textarea {
-  padding: 12px 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.04);
+.admin-access:hover,
+.admin-access:focus-visible {
   color: var(--text);
-  font: inherit;
-  resize: vertical;
-}
-
-.admin-forms input:focus,
-.admin-forms textarea:focus {
-  outline: 2px solid rgba(124, 92, 255, 0.4);
-  outline-offset: 0;
-}
-
-.admin-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  border-color: rgba(124, 92, 255, 0.6);
 }
 
 .form-error {
   margin: 0;
   color: #ff7a7a;
   font-size: 0.9rem;
-}
-
-.admin-dashboard h3,
-.admin-login h3 {
-  margin: 0;
-  font-size: 1.4rem;
-}
-
-.admin-login p,
-.admin-dashboard p {
-  margin: 0;
-  color: var(--muted);
-}
-
-body.modal-open {
-  overflow: hidden;
 }
 
 @media (max-width: 900px) {
@@ -676,9 +765,18 @@ body.modal-open {
     margin-top: 40px;
   }
 
-  .blog-heading {
-    flex-direction: column;
-    align-items: flex-start;
+  .auth-card {
+    padding: 36px;
+  }
+
+  .admin-main {
+    margin: 60px auto 100px;
+    padding: 0 20px;
+  }
+
+  .admin-blog__form,
+  .admin-blog__list {
+    padding: 24px;
   }
 }
 
@@ -705,6 +803,3 @@ body[data-theme='light'] .theme-toggle {
   color: var(--text);
 }
 
-body[data-theme='light'] .admin-modal {
-  background: rgba(244, 245, 250, 0.8);
-}


### PR DESCRIPTION
## Summary
- move the blog experience to a standalone page and update global navigation plus footer access for administrators
- add a dedicated login screen that verifies case-sensitive Antivity credentials before allowing entry
- build a protected admin dashboard that surfaces portfolio data and lets authenticated users publish blog posts with persistent storage
- refresh shared styling to support the new pages and subtle admin login link in the footer

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d629e0b6d8832fb3bf0e5bc6646409